### PR TITLE
Load https version of MathJax

### DIFF
--- a/editor.html
+++ b/editor.html
@@ -39,7 +39,7 @@ textarea {
     TeX: { equationNumbers: {autoNumber: "AMS"} }
   });
 </script>
-<script type="text/javascript" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
+<script type="text/javascript" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
 <script type="text/javascript" src="lib/marked/lib/marked.js"></script>
 
 <script>


### PR DESCRIPTION
The demo page is broken when it is loaded over https without this change due to mixed content issues