### PR TITLE
cdn.mathjax.org will close on April 30th 2017. Replace with cdnjs.cludflare.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ https://kerzol.github.io/markdown-mathjax/editor.html
 ## Dependencies
 
 - https://github.com/chjj/marked
-- https://cdn.mathjax.org/mathjax/latest/MathJax.js
+- https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js
 
 
 ## Install
@@ -32,6 +32,6 @@ Just type in the terminal:
     git submodule update
 ```
 
-We use MathJax from http://cdn.mathjax.org/. 
+We use MathJax from https://cdnjs.cloudflare.com/ajax/libs/mathjax/. 
 If you don't like that you need to read and modify _editor.html_
 

--- a/editor.html
+++ b/editor.html
@@ -39,7 +39,7 @@ textarea {
     TeX: { equationNumbers: {autoNumber: "AMS"} }
   });
 </script>
-<script type="text/javascript" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
 <script type="text/javascript" src="lib/marked/lib/marked.js"></script>
 
 <script>


### PR DESCRIPTION
See https://www.mathjax.org/cdn-shutting-down/ for more information.